### PR TITLE
Fix mlbdd installation

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,6 @@
 (library
-  (name MLBDD)
+  (public_name MLBDD)
+  (wrapped false)
   (modes byte native)
   (ocamlopt_flags (:standard -O3 -unsafe -unboxed-types -inline-max-unroll 2 -rounds 4))
 )


### PR DESCRIPTION
non-public libraries are not installed nor built during release