### PR TITLE
fixed typo in MLBDD.mli

### DIFF
--- a/lib/MLBDD.mli
+++ b/lib/MLBDD.mli
@@ -149,7 +149,7 @@ type man
     represents the formula *)
 type t
 
-(** [suppor] is the type of support for a BDD.  A support is the set of
+(** [support] is the type of support for a BDD.  A support is the set of
     variables that are needed to represent a formula *)
 type support
 


### PR DESCRIPTION
replaced `suppor` by `support` in `val support : t -> support` description